### PR TITLE
Task executor can now be prevented from interrupting tasks during on demand or pause operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ except rospy.ServiceException, e:
 	print "Service call failed: %s"%e		
 ```
 
+### Interruptibility at Execution Time
+
+By default the execution of tasks is interruptible (via actionlib preempt). If you do not wish your task to be interrupted you can provide the `IsTaskInterruptible.srv` service at the name `<task name>_is_interruptible`, e.g. `do_dishes_is_interruptible` from the example above. You can change the return value at runtime as this will be checked prior to interruption. 
+
 ## Creating a Routine
 
 The scenario use case for task execution is that the robot has a *daily routine* which is a list of tasks which it carries out every day. This can be created with the `task_routine.DailyRoutine` object which is configured with start and end times for the robot's daily activities:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ set_execution_status = rospy.ServiceProxy(set_exe_stat_srv_name, SetExecutionSta
 try:
 	# add task to the execution framework
     task_id = add_task_srv(task)
-    # make sure execution is running -- this only needs to be done onece      
+    # make sure execution is running -- this only needs to be done once      
     set_execution_status(True)
 except rospy.ServiceException, e: 
 	print "Service call failed: %s"%e		
@@ -134,6 +134,25 @@ except rospy.ServiceException, e:
 ### Interruptibility at Execution Time
 
 By default the execution of tasks is interruptible (via actionlib preempt). If you do not wish your task to be interrupted you can provide the `IsTaskInterruptible.srv` service at the name `<task name>_is_interruptible`, e.g. `do_dishes_is_interruptible` from the example above. You can change the return value at runtime as this will be checked prior to interruption. 
+
+Here's an example from the node which provides the `wait_action`.
+
+```python
+
+class WaitServer:
+    def __init__(self):         
+        self.server = actionlib.SimpleActionServer('wait_action', WaitAction, self.execute, False) 
+        self.server.start()
+        # this is not necessary in this node, but included for testing purposes
+        rospy.Service('wait_action_is_interruptible', IsTaskInterruptible, self.is_interruptible)
+
+    def is_interruptible(self, req):
+        # rospy.loginfo('Yes, interrupt me, go ahead')
+        # return True
+        rospy.loginfo('No, I will never stop')
+        return False
+
+```
 
 ## Creating a Routine
 

--- a/strands_executive_msgs/CMakeLists.txt
+++ b/strands_executive_msgs/CMakeLists.txt
@@ -38,6 +38,7 @@ add_service_files(
   AddMdpModel.srv
   UpdateNavStatistics.srv
   AddDeleteSpecialWaypoint.srv
+  IsTaskInterruptible.srv
 )
 
 

--- a/strands_executive_msgs/srv/DemandTask.srv
+++ b/strands_executive_msgs/srv/DemandTask.srv
@@ -1,4 +1,9 @@
 # The task to demanded from the execution system. This overrides all currently queued tasks and is executed immediately
 Task task
 ---
+# Whether the task was successfully demanded
+bool success
+# If successful, the id of the task that was demanded
 uint64 task_id
+# If not successful, how long you may have to wait until the call might be successful, i.e. how long is left on the current execution which refused to be interrupted
+duration remaining_execution_time

--- a/strands_executive_msgs/srv/IsTaskInterruptible.srv
+++ b/strands_executive_msgs/srv/IsTaskInterruptible.srv
@@ -1,0 +1,5 @@
+---
+# The current execution status
+bool status
+
+

--- a/strands_executive_msgs/srv/SetExecutionStatus.srv
+++ b/strands_executive_msgs/srv/SetExecutionStatus.srv
@@ -1,7 +1,10 @@
 # Set to true to start execution, or false to pause execution
 bool status
 ---
-# The state execution was in previously
+# The state execution was in before this call
 bool previous_status
-
+# Whether execution was successfully paused
+bool success
+# If not successful, how long you may have to wait until the call might be successful, i.e. how long is left on the current execution which refused to be interrupted
+duration remaining_execution_time
 

--- a/task_executor/scripts/example_demand_client.py
+++ b/task_executor/scripts/example_demand_client.py
@@ -28,24 +28,15 @@ if __name__ == '__main__':
     # get services to call into execution framework
     demand_task, set_execution_status = get_services()
 
-    # 
-    demanded_wait = Task(action='wait_action', max_duration=rospy.Duration(60), start_node_id='WayPoint2')
-    task_id = demand_task(demanded_wait)
-    print 'demanded task as id: %s' % task_id
-    
-    #demanded_fire = Task(action='CheckObjectPresenceAction', max_duration=rospy.Duration(60), start_node_id='WayPoint22')
-    #pan=0
-    #tilt=29
-    #object_id='fire_extinguisher_co2.pcd'
-    #task_utils.add_string_argument(demanded_fire, object_id)
-    #task_utils.add_float_argument(demanded_fire, pan)
-    #task_utils.add_float_argument(demanded_fire, tilt)
-
-    #task_id = demand_task(demanded_fire)
-
-  
-
     # Set the task executor running (if it isn't already)
     set_execution_status(True)
+    print 'set execution'
 
-    # rospy.spin()
+
+    # 
+    demanded_wait = Task(action='wait_action', max_duration=rospy.Duration(60), start_node_id='h_2')
+    resp = demand_task(demanded_wait)
+    print 'demanded task as id: %s' % resp.task_id
+    rospy.loginfo('Success: %s' % resp.success)
+    rospy.loginfo('Wait: %s' % resp.remaining_execution_time)
+

--- a/task_executor/scripts/example_multi_add_client.py
+++ b/task_executor/scripts/example_multi_add_client.py
@@ -20,7 +20,7 @@ def get_services():
     return add_tasks_srv, set_execution_status
 
 
-def create_wait_task(node, secs=rospy.Duration(5)):
+def create_wait_task(node, secs=rospy.Duration(10)):
     wait_task = Task(action='wait_action',start_node_id=node, end_node_id=node, max_duration=secs)
     task_utils.add_time_argument(wait_task, rospy.Time())
     task_utils.add_duration_argument(wait_task, secs)
@@ -43,7 +43,7 @@ if __name__ == '__main__':
     set_execution_status(True)
 
     # now let's stop execution while it's going on
-    rospy.sleep(2)
+    rospy.sleep(4)
     set_execution_status(False)
 
     # # and start again

--- a/task_executor/scripts/example_multi_add_client.py
+++ b/task_executor/scripts/example_multi_add_client.py
@@ -40,11 +40,13 @@ if __name__ == '__main__':
     task_id = add_task(tasks)
     
     # Set the task executor running (if it isn't already)
-    set_execution_status(True)
+    resp = set_execution_status(True)
 
     # now let's stop execution while it's going on
     rospy.sleep(4)
-    set_execution_status(False)
+    resp = set_execution_status(False)
+    rospy.loginfo('Success: %s' % resp.success)
+    rospy.loginfo('Wait: %s' % resp.remaining_execution_time)
 
     # # and start again
     # rospy.sleep(2)

--- a/wait_action/CMakeLists.txt
+++ b/wait_action/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   actionlib
   actionlib_msgs
   rospy
+  strands_executive_msgs
 )
 
 ## System dependencies are found with CMake's conventions

--- a/wait_action/package.xml
+++ b/wait_action/package.xml
@@ -39,6 +39,7 @@
   <run_depend>actionlib_msgs</run_depend>
   <run_depend>rospy</run_depend>
   <run_depend>std_srvs</run_depend>
+  <run_depend>strands_executive_msgs</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>

--- a/wait_action/scripts/wait_node.py
+++ b/wait_action/scripts/wait_node.py
@@ -17,9 +17,9 @@ class WaitServer:
 
     def is_interruptible(self, req):
         # rospy.loginfo('Yes, interrupt me, go ahead')
-        # return True
-        rospy.loginfo('No, I will never stop')
-        return False
+        return True
+        # rospy.loginfo('No, I will never stop')
+        # return False
 
     def end_wait(self, req):
         

--- a/wait_action/scripts/wait_node.py
+++ b/wait_action/scripts/wait_node.py
@@ -5,13 +5,21 @@ import actionlib
 from wait_action.msg import *
 from datetime import *
 from std_srvs.srv import Empty, EmptyResponse
+from strands_executive_msgs.srv import IsTaskInterruptible
+
 
 class WaitServer:
     def __init__(self):         
         self.server = actionlib.SimpleActionServer('wait_action', WaitAction, self.execute, False) 
         self.server.start()
+        # this is not necessary in this node, but included for testing purposes
+        rospy.Service('wait_action_is_interruptible', IsTaskInterruptible, self.is_interruptible)
 
-
+    def is_interruptible(self, req):
+        # rospy.loginfo('Yes, interrupt me, go ahead')
+        # return True
+        rospy.loginfo('No, I will never stop')
+        return False
 
     def end_wait(self, req):
         


### PR DESCRIPTION
By default the execution of tasks is interruptible (via actionlib preempt). If you do not wish your task to be interrupted you can provide the `IsTaskInterruptible.srv` service at the name `<task name>_is_interruptible`, e.g. `do_dishes_is_interruptible` from the example above. You can change the return value at runtime as this will be checked prior to interruption. The demand task and set execution status services now return more information about the result of the call. If the task executing when the call is received is interruptible, then the behaviour is as before. If it is not interruptible then the return value indicates this plus the amount of time you might need to wait until the uninterruptible task finishes. 

Here's an example of the interruptible service from the node which provides the `wait_action`.

``` python

class WaitServer:
    def __init__(self):         
        self.server = actionlib.SimpleActionServer('wait_action', WaitAction, self.execute, False) 
        self.server.start()
        # this is not necessary in this node, but included for testing purposes
        rospy.Service('wait_action_is_interruptible', IsTaskInterruptible, self.is_interruptible)

    def is_interruptible(self, req):
        # rospy.loginfo('Yes, interrupt me, go ahead')
        # return True
        rospy.loginfo('No, I will never stop')
        return False

```
