### PR TITLE
improve robustness of mdp stuff

### DIFF
--- a/mdp_plan_exec/scripts/mdp_policy_executor.py
+++ b/mdp_plan_exec/scripts/mdp_policy_executor.py
@@ -178,6 +178,9 @@ class MdpPolicyExecutor(object):
                     if prob_post_cond[1]["waypoint"]==waypoint_val:
                         self.current_prod_state=dict(prob_post_cond[1])
                         return
+        if self.current_prod_state["dra_state1"] == self.product_mdp.props_def["dra_acc_state1"].conds["dra_state1"]: 
+            rospy.loginfo("Skipping MDP state update as target state has already been visited")
+            return
         self.current_prod_state=None
         rospy.logerr("Error getting MDP next state. Aborting.")
         self.top_nav_policy_exec.cancel_all_goals()

--- a/mdp_plan_exec/scripts/mdp_policy_executor.py
+++ b/mdp_plan_exec/scripts/mdp_policy_executor.py
@@ -77,6 +77,9 @@ class MdpPolicyExecutor(object):
     def generate_prism_specification(self, goal):
         special_waypoints=self.special_waypoints_srv()
         if goal.task_type==ExecutePolicyGoal.GOTO_WAYPOINT:
+            if not self.top_map_mdp.target_in_topological_map(goal.target_id):
+                rospy.logerr("Execute policy target  " + goal.target_id  + "  is not a node in the topological map. Aborting")
+                return None
             if goal.target_id in special_waypoints.forbidden_waypoints:
                 rospy.logwarn("The goal is a forbidden waypoint. Aborting")
                 return None

--- a/mdp_plan_exec/scripts/mdp_travel_time_estimator.py
+++ b/mdp_plan_exec/scripts/mdp_travel_time_estimator.py
@@ -27,9 +27,12 @@ class MdpTravelTimeEstimator(object):
         rospy.loginfo("MDP travel times estimator initialised.")
 
     def travel_times_to_waypoint_cb(self,req):
+        if not self.top_map_mdp.target_in_topological_map(req.target_waypoint):
+            rospy.logerr("Get travel times target  " + req.target_waypoint  + "  is not a node in the topological map. Returning empty response")
+            return GetExpectedTravelTimesToWaypointResponse()
         if req.epoch != self.last_epoch:
             self.last_epoch=req.epoch
-            self.top_map_mdp.set_mdp_action_durations(self.directory+self.file_name, req.epoch)            
+            self.top_map_mdp.set_mdp_action_durations(self.directory+self.file_name, req.epoch)           
         specification='R{"time"}min=? [ ( F "' + req.target_waypoint + '") ]'
         rospy.loginfo("The specification is " + specification)
         state_vector=map(rospy.Duration, self.prism_estimator.get_state_vector(specification))

--- a/mdp_plan_exec/src/mdp_plan_exec/top_map_mdp.py
+++ b/mdp_plan_exec/src/mdp_plan_exec/top_map_mdp.py
@@ -103,4 +103,7 @@ class TopMapMdp(Mdp):
 
     def set_initial_state_from_waypoint(self,current_waypoint):
         self.initial_state=self.props_def[current_waypoint].conds
+        
+    def target_in_topological_map(self, waypoint):
+        return waypoint in [node.name for node in self.top_map.nodes]
 


### PR DESCRIPTION
@hawesie the `/mdp_plan_exec/get_expected_travel_times` service now gives an empty response when the target_id is not in the topological map, to avoid the system breaking down completely when someone adds tasks with wrong waypoints. I guess the executor needs to be extended to handle this.
