### PR TITLE
Added a verbose option to the schedule printer.

### DIFF
--- a/task_executor/scripts/schedule_status.py
+++ b/task_executor/scripts/schedule_status.py
@@ -29,8 +29,15 @@ def callback(data):
         rospy.loginfo("Execution to start at %s", start_time(data.execution_queue[0]))
     
     if len(data.execution_queue) > 0:
+        
         rospy.loginfo("A further %s tasks queued for execution", len(data.execution_queue) - 1)
 
+        if rospy.get_param('schedule_verbose', False):
+            for i in range(1, min(rospy.get_param('schedule_limit', 10), len(data.execution_queue))):
+                rospy.loginfo('%s: %s at %s' % (i, pretty(data.execution_queue[i]), start_time(data.execution_queue[i])))   
+
+        
+        
 
 if __name__ == '__main__':
     rospy.init_node('schedule_status_printer')


### PR DESCRIPTION
If you do `rosparam set schedule_verbose true` you can now see the tasks which are scheduled. Use `rosparam set schedule_limit 10` etc. to limit the number of tasks printed.
