### PR TITLE
Filtering out unexecutable tasks from the routine.

### DIFF
--- a/task_executor/scripts/schedule_status.py
+++ b/task_executor/scripts/schedule_status.py
@@ -18,12 +18,17 @@ def pretty(task):
 def start_time(task):
     return datetime.fromtimestamp(task.execution_time.secs)
 
+def end_time(task):
+    return datetime.fromtimestamp((task.execution_time + task.max_duration).secs)
+
+
 def callback(data):
     rospy.loginfo("\n\n\n\n\n\n");
 
     if data.currently_executing:
         rospy.loginfo("Currently executing %s", pretty(data.execution_queue[0]))
         rospy.loginfo("Task started at %s", start_time(data.execution_queue[0]))        
+        rospy.loginfo("      finish by %s", end_time(data.execution_queue[0]))        
     elif len(data.execution_queue) > 0:
         rospy.loginfo("Waiting to execute %s", pretty(data.execution_queue[0]))
         rospy.loginfo("Execution to start at %s", start_time(data.execution_queue[0]))

--- a/task_executor/src/task_executor/sm_base_executor.py
+++ b/task_executor/src/task_executor/sm_base_executor.py
@@ -244,9 +244,11 @@ class AbstractTaskExecutor(BaseTaskExecutor):
 
                 # create a concurrence which monitors execution time
                 nav_concurrence = smach.Concurrence(outcomes=['succeeded', 'preempted', 'aborted'],
-                                        default_outcome='aborted',
+                                        default_outcome='preempted',
                                         outcome_cb=self.outcome_cb,
-                                        child_termination_cb=concurrence_child_term_cb)
+                                        child_termination_cb=concurrence_child_term_cb,
+                                        # give states 30 seconds to service a request to shut down
+                                        termination_timeout = 30)
                 # register callback for logging
                 nav_concurrence.register_start_cb(self.nav_start_cb)
                 nav_concurrence.register_termination_cb(self.nav_termination_cb)
@@ -296,9 +298,11 @@ class AbstractTaskExecutor(BaseTaskExecutor):
 
                     # create a concurrence which monitors execution time along with doing the execution
                     action_concurrence = smach.Concurrence(outcomes=['succeeded', 'preempted', 'aborted'],
-                                            default_outcome='aborted',
+                                            default_outcome='preempted',
                                             outcome_cb=self.outcome_cb,
-                                            child_termination_cb=concurrence_child_term_cb)
+                                            child_termination_cb=concurrence_child_term_cb,
+                                            # give states 30 seconds to service a request to shut down
+                                            termination_timeout = 30)
 
                     # register callback for logging
                     action_concurrence.register_start_cb(self.action_start_cb)
@@ -350,7 +354,7 @@ class AbstractTaskExecutor(BaseTaskExecutor):
         return successfully_joined
 
     def cancel_active_task(self):
-        preempt_timeout_secs = 30
+        preempt_timeout_secs = 60
         if self.task_sm is not None:
             rospy.loginfo('Requesting preempt on state machine in state %s' % self.task_sm.get_active_states())
             self.task_sm.request_preempt()


### PR DESCRIPTION
This has become necessary since the abilty to add daily tasks allows the addition of arbitrary tasks which are no longer bounded sensibly in time by the routine windows.

Also this now deals with runaway and non-terminating child processes.
## HOWEVER this needs a different fork of SMACH

Either 

1) an update to SMACH if/when this PR is in: https://github.com/ros/executive_smach/pull/37

Or

2) https://github.com/hawesie/executive_smach

So 2) as of April 23, 2015.
