### PR TITLE
Consider navigation time when deciding when to execute tasks.

### DIFF
--- a/task_executor/CMakeLists.txt
+++ b/task_executor/CMakeLists.txt
@@ -63,13 +63,13 @@ catkin_python_setup()
 
 # Generate actions in the 'action' folder
 add_action_files(
-  FILES
-  TestExecution.action
+  FILES TestExecution.action TaskTest.action
 )
 
 # Generate added messages and services with any dependencies listed here
-generate_messages(
-  DEPENDENCIES
+generate_messages(  
+  DEPENDENCIES 
+  strands_executive_msgs
   geometry_msgs
   actionlib_msgs
 )

--- a/task_executor/CMakeLists.txt
+++ b/task_executor/CMakeLists.txt
@@ -127,6 +127,7 @@ if (CATKIN_ENABLE_TESTING)
   find_package(catkin REQUIRED COMPONENTS rostest)
   # add_rostest(tests/fifo_tester.test)
   add_rostest(tests/scheduled_exe_tester.test)
+  add_rostest(tests/time_tester.test)
 endif()
 
 

--- a/task_executor/action/TaskTest.action
+++ b/task_executor/action/TaskTest.action
@@ -1,0 +1,4 @@
+strands_executive_msgs/Task task
+---
+bool success
+---

--- a/task_executor/scripts/scheduled_task_executor.py
+++ b/task_executor/scripts/scheduled_task_executor.py
@@ -38,7 +38,7 @@ class ScheduledTaskExecutor(AbstractTaskExecutor):
         self.unscheduled_tasks = Queue()
        
         # data structure that manages tasks
-        self.execution_schedule = ExecutionSchedule()
+        self.execution_schedule = ExecutionSchedule(travel_duration_fn=self.expected_navigation_duration_now)
 
        
         self.running = False

--- a/task_executor/src/task_executor/utils.py
+++ b/task_executor/src/task_executor/utils.py
@@ -1,7 +1,7 @@
 import rospy
 import actionlib 
 from task_executor.msg import *
-from datetime import datetime
+from datetime import datetime, timedelta
 from std_msgs.msg import String
 
 class TestTaskAction(object):
@@ -91,5 +91,7 @@ class CheckTaskActionServer(object):
 def rostime_to_python(rtime):
     return datetime.fromtimestamp(rtime.to_sec())        
 
+def rosduration_to_python(rdur):
+    return timedelta(seconds=rdur.to_sec())        
 
 

--- a/task_executor/src/task_executor/utils.py
+++ b/task_executor/src/task_executor/utils.py
@@ -2,7 +2,7 @@ import rospy
 import actionlib 
 from task_executor.msg import *
 from datetime import datetime
-
+from std_msgs.msg import String
 
 class TestTaskAction(object):
     """ 
@@ -30,5 +30,66 @@ class TestTaskAction(object):
         self.task_server.start()
 
 
+class CheckTaskActionServer(object):
+    """ 
+    Creates the action servers the example tasks require.
+    """
+    def __init__(self, result_fn=None):
+        self.current_node = None
+        self.result_fn = result_fn
+
+        rospy.Subscriber('/current_node', String, self.update_topological_location, queue_size=2)
+        while self.current_node is None and not rospy.is_shutdown():
+            rospy.sleep(0.5)
+
+        self.task_server = actionlib.SimpleActionServer('check_task', TaskTestAction, execute_cb = self.execute, auto_start = False)        
+
+    def update_topological_location(self, node_name):
+        self.current_node = node_name.data
+        
+    def execute(self, goal):
+
+        now = rospy.get_rostime()
+
+        result = TaskTestResult()
+        result.success = True
+
+        task = goal.task
+
+        if task.start_node_id != self.current_node:
+            result.success = False
+            rospy.logwarn('Start node incorrect')        
+
+        rospy.loginfo('        now: %s' % rostime_to_python(now))
+        rospy.loginfo('start after: %s' % rostime_to_python(task.start_after))
+        rospy.loginfo(' end before: %s' % rostime_to_python(task.end_before))
+
+        if now < task.start_after:
+            result.success = False
+            rospy.logwarn('Task started before window is open')
+            rospy.logwarn('        now: %s' % rostime_to_python(now))
+            rospy.logwarn('start after: %s' % rostime_to_python(task.start_after))
+
+        if now + task.max_duration > task.end_before:
+            result.success = False
+            rospy.logwarn('Task could end after window')
+            rospy.logwarn('max end time: %s' % rostime_to_python(now + task.max_duration))
+            rospy.logwarn('  end before: %s' % rostime_to_python(task.end_before))   
+
+        if self.result_fn is not None:
+            self.result_fn(result.success)
+
+        if self.task_server.is_preempt_requested():
+            self.task_server.set_preempted(result)
+        else:
+            self.task_server.set_succeeded(result)
+
+    def start(self):
+        self.task_server.start()
+
+
 def rostime_to_python(rtime):
-    return datetime.utcfromtimestamp(rtime.to_sec())        
+    return datetime.fromtimestamp(rtime.to_sec())        
+
+
+

--- a/task_executor/tests/scheduled_exe_tester.py
+++ b/task_executor/tests/scheduled_exe_tester.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 PKG = 'task_executor'
-NAME = 'fifo_tester'
+NAME = 'scheduled_exe_tester'
 
 import rospy
 import unittest

--- a/task_executor/tests/time_tester.py
+++ b/task_executor/tests/time_tester.py
@@ -77,7 +77,7 @@ class TestTaskTimings(object):
         travel_time = time_srv(current_node, task.start_node_id).travel_time
         task.max_duration = rospy.Duration(travel_time.to_sec()/4)
         task.start_after = now + delay + travel_time
-        task.end_before = task.start_after + task.max_duration
+        task.end_before = task.start_after + rospy.Duration(travel_time.to_sec()/2)
 
         # add the task argument which is a reference to a copy of itself in the db
         object_id = msg_store.insert(task)

--- a/task_executor/tests/time_tester.py
+++ b/task_executor/tests/time_tester.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python
+PKG = 'task_executor'
+NAME = 'time_tester'
+
+import rospy
+import unittest
+import rostest
+import random
+
+import actionlib
+from strands_executive_msgs.msg import Task
+from task_executor.msg import *
+from task_executor.utils import CheckTaskActionServer, rostime_to_python
+from Queue import Queue
+from random import randrange
+from mongodb_store.message_store import MessageStoreProxy
+from geometry_msgs.msg import Pose, Point, Quaternion
+from strands_executive_msgs import task_utils
+from strands_executive_msgs.msg import Task
+from strands_executive_msgs.srv import AddTasks, SetExecutionStatus
+from topological_navigation.msg import GotoNodeAction
+from strands_navigation_msgs.msg import TopologicalMap
+from strands_navigation_msgs.srv import EstimateTravelTime
+from std_msgs.msg import String
+        
+def get_services():
+    # get services necessary to do the jon
+    add_tasks_srv_name = '/task_executor/add_tasks'
+    set_exe_stat_srv_name = '/task_executor/set_execution_status'
+    rospy.loginfo("Waiting for task_executor service...")
+    rospy.wait_for_service(add_tasks_srv_name)
+    rospy.wait_for_service(set_exe_stat_srv_name)
+    rospy.loginfo("Done")        
+    add_tasks_srv = rospy.ServiceProxy(add_tasks_srv_name, AddTasks)
+    set_execution_status = rospy.ServiceProxy(set_exe_stat_srv_name, SetExecutionStatus)
+    return add_tasks_srv, set_execution_status
+
+
+class TestTaskTimings(object):
+    """ 
+    Creates the action servers the example tasks require.
+    """
+    def __init__(self):
+        self.current_node = None
+
+        rospy.Subscriber('/current_node', String, self.update_topological_location, queue_size=2)
+        while self.current_node is None and not rospy.is_shutdown():
+            rospy.sleep(0.5)
+
+    def update_topological_location(self, node_name):
+        self.current_node = node_name.data
+        
+    def execute(self):
+
+        msg_store = MessageStoreProxy() 
+
+        # now wait for the distance service
+        time_srv_name = 'topological_navigation/travel_time_estimator'
+        rospy.wait_for_service(time_srv_name, timeout=10)
+        time_srv = rospy.ServiceProxy(time_srv_name, EstimateTravelTime)
+        # print(time_srv("ChargingPoint", "v_1"))
+        # print(time_srv("ChargingPoint", "v_2"))
+
+        task_checker = CheckTaskActionServer()
+        task_checker.start()
+
+        now = rospy.get_rostime()
+        delay = rospy.Duration(5)
+
+        current_node = self.current_node
+
+
+        task = Task()
+        task.action = 'check_task'
+        task.start_node_id = 'v_1'
+        # make sure action dur
+        travel_time = time_srv(current_node, task.start_node_id).travel_time
+        task.max_duration = rospy.Duration(travel_time.to_sec()/4)
+        task.start_after = now + delay + travel_time
+        task.end_before = task.start_after + task.max_duration
+
+        # add the task argument which is a reference to a copy of itself in the db
+        object_id = msg_store.insert(task)
+        task_utils.add_object_id_argument(task, object_id, Task)
+
+        client = actionlib.SimpleActionClient('check_task', TaskTestAction)
+        client.wait_for_server()
+
+        # get services to call into execution framework
+        add_tasks, set_execution_status = get_services()
+
+
+        add_tasks([task])
+        set_execution_status(True)
+
+
+
+
+if __name__ == '__main__':
+    # rostest.rosrun(PKG, NAME, TestEntry, sys.argv)
+    rospy.init_node(NAME)
+    executor = TestTaskTimings()        
+    executor.execute()
+
+    rospy.spin()
+
+

--- a/task_executor/tests/time_tester.test
+++ b/task_executor/tests/time_tester.test
@@ -1,0 +1,15 @@
+<launch>
+  
+  <include file="$(find mongodb_store)/launch/mongodb_store.launch">
+  	<arg name="test_mode" default="true" />
+  </include>
+
+  <include file="$(find topological_utils)/launch/dummy_topological_navigation.launch" >
+  	<arg name="simulate_time" default="true" />
+  </include>
+
+  <include file="$(find task_executor)/launch/task-scheduler-top.launch" />
+  
+  <test test-name="time_tester" pkg="task_executor" type="time_tester.py" time-limit="40" />
+
+</launch>


### PR DESCRIPTION
This PR updates the task executor to ensure navigation happens prior to the opening of the task execution window (`task.start_after`) rather than considering that the window indicated the start of the navigation time. There is a new test to verify this. a1be3ee adds the logic, the other commits are testing code.
