### PR TITLE
Automatically set relaxed_nav parameter.

### DIFF
--- a/task_executor/launch/task-scheduler-mdp.launch
+++ b/task_executor/launch/task-scheduler-mdp.launch
@@ -15,6 +15,13 @@
   	<param name="nav_service" type="string" value="mdp" />
   </node>
 
+  <!-- node which determines whether navigation should be strict with timings -->
+  <node pkg="task_executor" type="nav_relaxant.py" name="nav_relaxant"  output="screen">
+    <!-- How many nav stats per edge are sufficient for us to trust the estimate -->
+    <param name="count_threshold" type="int" value="10" />
+  </node>
+
+
   
   <!-- Utility node used for generating wait behaviours -->
   <node pkg="wait_action" type="wait_node.py" name="wait_action"  output="screen"/>    

--- a/task_executor/launch/task-scheduler-mdp.launch
+++ b/task_executor/launch/task-scheduler-mdp.launch
@@ -18,7 +18,7 @@
   <!-- node which determines whether navigation should be strict with timings -->
   <node pkg="task_executor" type="nav_relaxant.py" name="nav_relaxant"  output="screen">
     <!-- How many nav stats per edge are sufficient for us to trust the estimate -->
-    <param name="count_threshold" type="int" value="10" />
+    <param name="count_threshold" type="int" value="3" />
   </node>
 
 

--- a/task_executor/launch/task-scheduler-mdp.launch
+++ b/task_executor/launch/task-scheduler-mdp.launch
@@ -18,7 +18,7 @@
   <!-- node which determines whether navigation should be strict with timings -->
   <node pkg="task_executor" type="nav_relaxant.py" name="nav_relaxant"  output="screen">
     <!-- How many nav stats per edge are sufficient for us to trust the estimate -->
-    <param name="count_threshold" type="int" value="3" />
+    <param name="count_threshold" type="int" value="5" />
   </node>
 
 

--- a/task_executor/launch/task-scheduler-top.launch
+++ b/task_executor/launch/task-scheduler-top.launch
@@ -7,6 +7,12 @@
   	  <param name="nav_service" type="string" value="topological_nav" />
   </node>
 
+  <!-- node which determines whether navigation should be strict with timings -->
+  <node pkg="task_executor" type="nav_relaxant.py" name="nav_relaxant"  output="screen">
+  	<!-- How many nav stats per edge are sufficient for us to trust the estimate -->
+    <param name="count_threshold" type="int" value="10" />
+  </node>
+
   <!-- Utility node used for generating wait behaviours -->
   <node pkg="wait_action" type="wait_node.py" name="wait_action"  output="screen"/>    
 

--- a/task_executor/launch/task-scheduler-top.launch
+++ b/task_executor/launch/task-scheduler-top.launch
@@ -10,7 +10,7 @@
   <!-- node which determines whether navigation should be strict with timings -->
   <node pkg="task_executor" type="nav_relaxant.py" name="nav_relaxant"  output="screen">
   	<!-- How many nav stats per edge are sufficient for us to trust the estimate -->
-    <param name="count_threshold" type="int" value="10" />
+    <param name="count_threshold" type="int" value="3" />
   </node>
 
   <!-- Utility node used for generating wait behaviours -->

--- a/task_executor/launch/task-scheduler-top.launch
+++ b/task_executor/launch/task-scheduler-top.launch
@@ -10,7 +10,7 @@
   <!-- node which determines whether navigation should be strict with timings -->
   <node pkg="task_executor" type="nav_relaxant.py" name="nav_relaxant"  output="screen">
   	<!-- How many nav stats per edge are sufficient for us to trust the estimate -->
-    <param name="count_threshold" type="int" value="3" />
+    <param name="count_threshold" type="int" value="5" />
   </node>
 
   <!-- Utility node used for generating wait behaviours -->

--- a/task_executor/scripts/example_add_client.py
+++ b/task_executor/scripts/example_add_client.py
@@ -42,5 +42,5 @@ if __name__ == '__main__':
     set_execution_status(True)
 
     # now let's stop execution while it's going on
-    rospy.sleep(int(sys.argv[2])/2)
-    set_execution_status(False)
+    # rospy.sleep(int(sys.argv[2])/2)
+    # set_execution_status(False)

--- a/task_executor/scripts/nav_relaxant.py
+++ b/task_executor/scripts/nav_relaxant.py
@@ -52,34 +52,34 @@ class NavRelaxant(object):
     def start(self):
         Thread(target=self.run).start()
 
-    def generate_edge_task(self, start, end, edge_id, window_size):
-        rospy.loginfo('Generating edge task %s to %s via %s' % (start, end, edge_id))
+    # def generate_edge_task(self, start, end, edge_id, window_size):
+    #     rospy.loginfo('Generating edge task %s to %s via %s' % (start, end, edge_id))
 
-        # get task services
-        add_task_srv_name = '/task_executor/add_tasks'
-        rospy.loginfo("Waiting for task_executor service...")
-        rospy.wait_for_service(add_task_srv_name)
-        rospy.loginfo("Done")        
-        add_tasks_srv = rospy.ServiceProxy(add_task_srv_name, AddTasks)
+    #     # get task services
+    #     add_task_srv_name = '/task_executor/add_tasks'
+    #     rospy.loginfo("Waiting for task_executor service...")
+    #     rospy.wait_for_service(add_task_srv_name)
+    #     rospy.loginfo("Done")        
+    #     add_tasks_srv = rospy.ServiceProxy(add_task_srv_name, AddTasks)
         
-        # create a task to use the edge in question
-        task = Task()
-        task.action = '/topological_navigation/execute_policy_mode'
-        task.max_duration = rospy.Duration(300)
-        task.start_after = rospy.get_rostime()
-        task.end_before = task.start_after + rospy.Duration(window_size)
-        task.start_node_id = start
-        task.end_node_id = end
+    #     # create a task to use the edge in question
+    #     task = Task()
+    #     task.action = '/topological_navigation/execute_policy_mode'
+    #     task.max_duration = rospy.Duration(300)
+    #     task.start_after = rospy.get_rostime()
+    #     task.end_before = task.start_after + rospy.Duration(window_size)
+    #     task.start_node_id = start
+    #     task.end_node_id = end
 
-        route = NavRoute()
-        route.source = [start]
-        route.edge_id = [edge_id]
+    #     route = NavRoute()
+    #     route.source = [start]
+    #     route.edge_id = [edge_id]
 
-        msg_store = MessageStoreProxy()
-        task_utils.add_object_id_argument(task, msg_store.insert(route), NavRoute)
+    #     msg_store = MessageStoreProxy()
+    #     task_utils.add_object_id_argument(task, msg_store.insert(route), NavRoute)
 
-        # add the task
-        add_tasks_srv([task])
+    #     # add the task
+    #     add_tasks_srv([task])
 
 
     def run(self):
@@ -102,8 +102,8 @@ class NavRelaxant(object):
                         rospy.set_param('relaxed_nav', relax_should_be)
                         rospy.loginfo('Transitioning relaxed_nav parameter to: %s' % relax_should_be)       
                     
-                    if relax_should_be and rospy.get_param('explore_edges', True):
-                        self.generate_edge_task(*edge_tuple, window_size=repeat_window_secs)
+                    # if relax_should_be and rospy.get_param('explore_edges', True):
+                    #     self.generate_edge_task(*edge_tuple, window_size=repeat_window_secs)
 
             except Exception, e:
                 rospy.logwarn('while checking relaxation state: %s' % e)
@@ -113,6 +113,6 @@ class NavRelaxant(object):
 
 if __name__ == '__main__':
     rospy.init_node('nav_relaxant')
-    relaxant = NavRelaxant(count_threshold=rospy.get_param('~count_threshold', 10))
+    relaxant = NavRelaxant(count_threshold=rospy.get_param('~count_threshold', 5))
     relaxant.run()
     rospy.spin()

--- a/task_executor/scripts/nav_relaxant.py
+++ b/task_executor/scripts/nav_relaxant.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+import rospy
+from strands_navigation_msgs.msg import TopologicalMap, NavStatistics
+from mongodb_store.message_store import MessageStoreProxy
+
+class NavRelaxant(object):
+	def __init__(self, count_threshold):
+		super(NavRelaxant, self).__init__()		
+		rospy.Subscriber('topological_map', TopologicalMap, self.map_callback)
+		self.msg_store = MessageStoreProxy(collection='nav_stats')
+		self.node_pairs = []
+		self._allowed_to_turn_relax_on = True
+		self._allowed_to_turn_relax_off = True
+		self._count_threshold =  count_threshold
+
+
+	def map_callback(self, msg):        	
+		self.node_pairs = []
+		for node in msg.nodes:
+			for edge in node.edges:
+				self.node_pairs.append((node.name, edge.node))				
+
+
+	def pair_ok(self, start, end):
+		"""
+			Report if we are happy with the stats between these two nodes
+		"""
+		count = len(self.msg_store.query(NavStatistics._type, {"origin": start, "target": end, "final_node": end}))
+		rospy.logdebug('nav stat check %s %s %s' % (start, end, count))
+		return count > self._count_threshold
+
+
+	def nav_stats_require_relaxed_operation(self):
+		for (start, end) in self.node_pairs:
+			if not self.pair_ok(start, end):
+				rospy.loginfo('Nav stats from %s to %s not sufficient to stop being relaxed' % (start, end))
+				return True
+		return False
+
+
+	def run(self):
+		rate = rospy.Rate(0.016) 
+		
+		while not rospy.is_shutdown():
+
+			try:
+
+				relax_is_on = rospy.get_param('relaxed_nav', False)			
+
+				if (relax_is_on and self._allowed_to_turn_relax_off) or (not relax_is_on and self._allowed_to_turn_relax_on):
+					relax_should_be = self.nav_stats_require_relaxed_operation()	
+					if relax_is_on != relax_should_be:
+						rospy.set_param('relaxed_nav', relax_should_be)
+						rospy.loginfo('Transitioning relaxed_nav parameter to: %s' % relax_should_be)		
+
+			except Exception, e:
+				rospy.logwarn('while checking relaxation state: %s' % e)
+
+			finally:
+				rate.sleep()
+
+if __name__ == '__main__':
+	rospy.init_node('nav_relaxant')
+	relaxant = NavRelaxant(count_threshold=rospy.get_param('~count_threshold', 10))
+	relaxant.run()
+
+

--- a/task_executor/scripts/nav_relaxant.py
+++ b/task_executor/scripts/nav_relaxant.py
@@ -1,68 +1,118 @@
 #!/usr/bin/env python
 
 import rospy
-from strands_navigation_msgs.msg import TopologicalMap, NavStatistics
+from strands_navigation_msgs.msg import TopologicalMap, NavStatistics, NavRoute
 from mongodb_store.message_store import MessageStoreProxy
+from strands_executive_msgs.msg import Task
+from strands_executive_msgs.srv import AddTasks
+from strands_executive_msgs import task_utils
 
 class NavRelaxant(object):
-	def __init__(self, count_threshold):
-		super(NavRelaxant, self).__init__()		
-		rospy.Subscriber('topological_map', TopologicalMap, self.map_callback)
-		self.msg_store = MessageStoreProxy(collection='nav_stats')
-		self.node_pairs = []
-		self._allowed_to_turn_relax_on = True
-		self._allowed_to_turn_relax_off = True
-		self._count_threshold =  count_threshold
+    def __init__(self, count_threshold):
+        super(NavRelaxant, self).__init__()     
+        rospy.Subscriber('topological_map', TopologicalMap, self.map_callback)
+        self.msg_store = MessageStoreProxy(collection='nav_stats')
+        self.node_pairs = []
+        self._allowed_to_turn_relax_on = True
+        self._allowed_to_turn_relax_off = True
+        self._count_threshold =  count_threshold
 
 
-	def map_callback(self, msg):        	
-		self.node_pairs = []
-		for node in msg.nodes:
-			for edge in node.edges:
-				self.node_pairs.append((node.name, edge.node))				
+    def map_callback(self, msg):            
+        node_pairs = []
+        for node in msg.nodes:
+            for edge in node.edges:
+                node_pairs.append((node.name, edge.node, edge.edge_id))                
+        self.node_pairs = node_pairs
+
+    def pair_ok(self, start, end):
+        """
+            Report if we are happy with the stats between these two nodes
+        """
+        count = len(self.msg_store.query(NavStatistics._type, {"origin": start, "target": end, "final_node": end}))
+        rospy.logdebug('nav stat check %s %s %s' % (start, end, count))
+        return count > self._count_threshold
 
 
-	def pair_ok(self, start, end):
-		"""
-			Report if we are happy with the stats between these two nodes
-		"""
-		count = len(self.msg_store.query(NavStatistics._type, {"origin": start, "target": end, "final_node": end}))
-		rospy.logdebug('nav stat check %s %s %s' % (start, end, count))
-		return count > self._count_threshold
+    def nav_stats_require_relaxed_operation(self):
+
+        # only really needed for testing
+        while len(self.node_pairs) == 0 and not rospy.is_shutdown():
+            rospy.sleep(1)
+            rospy.loginfo('Waiting for nodes')
 
 
-	def nav_stats_require_relaxed_operation(self):
-		for (start, end) in self.node_pairs:
-			if not self.pair_ok(start, end):
-				rospy.loginfo('Nav stats from %s to %s not sufficient to stop being relaxed' % (start, end))
-				return True
-		return False
+        for (start, end, edge_id) in self.node_pairs:
+            if not self.pair_ok(start, end):
+                rospy.loginfo('Nav stats from %s to %s not sufficient to stop being relaxed' % (start, end))
+                return True, (start, end, edge_id)
+        return False, None
 
 
-	def run(self):
-		rate = rospy.Rate(0.016) 
-		
-		while not rospy.is_shutdown():
+    def start(self):
+        Thread(target=self.run).start()
 
-			try:
+    def generate_edge_task(self, start, end, edge_id, window_size):
+        rospy.loginfo('Generating edge task %s to %s via %s' % (start, end, edge_id))
 
-				relax_is_on = rospy.get_param('relaxed_nav', False)			
+        # get task services
+        add_task_srv_name = '/task_executor/add_tasks'
+        rospy.loginfo("Waiting for task_executor service...")
+        rospy.wait_for_service(add_task_srv_name)
+        rospy.loginfo("Done")        
+        add_tasks_srv = rospy.ServiceProxy(add_task_srv_name, AddTasks)
+        
+        # create a task to use the edge in question
+        task = Task()
+        task.action = '/topological_navigation/execute_policy_mode'
+        task.max_duration = rospy.Duration(300)
+        task.start_after = rospy.get_rostime()
+        task.end_before = task.start_after + rospy.Duration(window_size)
+        task.start_node_id = start
+        task.end_node_id = end
 
-				if (relax_is_on and self._allowed_to_turn_relax_off) or (not relax_is_on and self._allowed_to_turn_relax_on):
-					relax_should_be = self.nav_stats_require_relaxed_operation()	
-					if relax_is_on != relax_should_be:
-						rospy.set_param('relaxed_nav', relax_should_be)
-						rospy.loginfo('Transitioning relaxed_nav parameter to: %s' % relax_should_be)		
+        route = NavRoute()
+        route.source = [start]
+        route.edge_id = [edge_id]
 
-			except Exception, e:
-				rospy.logwarn('while checking relaxation state: %s' % e)
+        msg_store = MessageStoreProxy()
+        task_utils.add_object_id_argument(task, msg_store.insert(route), NavRoute)
 
-			finally:
-				rate.sleep()
+        # add the task
+        add_tasks_srv([task])
+
+
+    def run(self):
+        # rate = rospy.Rate(0.5) 
+
+        repeat_window_secs = 60.0 * 20.0
+        rate = rospy.Rate(1.0/repeat_window_secs) 
+
+        while not rospy.is_shutdown():
+
+            try:
+
+                relax_is_on = rospy.get_param('relaxed_nav', False)         
+                rospy.loginfo('relax_is_on %s' % relax_is_on)
+
+                if (relax_is_on and self._allowed_to_turn_relax_off) or (not relax_is_on and self._allowed_to_turn_relax_on):
+                    relax_should_be, edge_tuple = self.nav_stats_require_relaxed_operation()    
+                    
+                    if relax_is_on != relax_should_be:
+                        rospy.set_param('relaxed_nav', relax_should_be)
+                        rospy.loginfo('Transitioning relaxed_nav parameter to: %s' % relax_should_be)       
+                    
+                    if relax_should_be and rospy.get_param('explore_edges', True):
+                        self.generate_edge_task(*edge_tuple, window_size=repeat_window_secs)
+
+            except Exception, e:
+                rospy.logwarn('while checking relaxation state: %s' % e)
+
+            finally:
+                rate.sleep()
 
 if __name__ == '__main__':
-	rospy.init_node('nav_relaxant')
-	relaxant = NavRelaxant(count_threshold=rospy.get_param('~count_threshold', 10))
-	relaxant.run()
-
-
+    rospy.init_node('nav_relaxant')
+    relaxant = NavRelaxant(count_threshold=rospy.get_param('~count_threshold', 10))
+    relaxant.run()
+    rospy.spin()

--- a/task_executor/scripts/nav_relaxant.py
+++ b/task_executor/scripts/nav_relaxant.py
@@ -10,9 +10,9 @@ from strands_executive_msgs import task_utils
 class NavRelaxant(object):
     def __init__(self, count_threshold):
         super(NavRelaxant, self).__init__()     
+        self.node_pairs = []
         rospy.Subscriber('topological_map', TopologicalMap, self.map_callback)
         self.msg_store = MessageStoreProxy(collection='nav_stats')
-        self.node_pairs = []
         self._allowed_to_turn_relax_on = True
         self._allowed_to_turn_relax_off = True
         self._count_threshold =  count_threshold
@@ -48,41 +48,9 @@ class NavRelaxant(object):
                 return True, (start, end, edge_id)
         return False, None
 
-
-    def start(self):
-        Thread(target=self.run).start()
-
-    # def generate_edge_task(self, start, end, edge_id, window_size):
-    #     rospy.loginfo('Generating edge task %s to %s via %s' % (start, end, edge_id))
-
-    #     # get task services
-    #     add_task_srv_name = '/task_executor/add_tasks'
-    #     rospy.loginfo("Waiting for task_executor service...")
-    #     rospy.wait_for_service(add_task_srv_name)
-    #     rospy.loginfo("Done")        
-    #     add_tasks_srv = rospy.ServiceProxy(add_task_srv_name, AddTasks)
-        
-    #     # create a task to use the edge in question
-    #     task = Task()
-    #     task.action = '/topological_navigation/execute_policy_mode'
-    #     task.max_duration = rospy.Duration(300)
-    #     task.start_after = rospy.get_rostime()
-    #     task.end_before = task.start_after + rospy.Duration(window_size)
-    #     task.start_node_id = start
-    #     task.end_node_id = end
-
-    #     route = NavRoute()
-    #     route.source = [start]
-    #     route.edge_id = [edge_id]
-
-    #     msg_store = MessageStoreProxy()
-    #     task_utils.add_object_id_argument(task, msg_store.insert(route), NavRoute)
-
-    #     # add the task
-    #     add_tasks_srv([task])
-
-
     def run(self):
+
+        # for testing
         # rate = rospy.Rate(0.5) 
 
         repeat_window_secs = 60.0 * 20.0
@@ -102,9 +70,6 @@ class NavRelaxant(object):
                         rospy.set_param('relaxed_nav', relax_should_be)
                         rospy.loginfo('Transitioning relaxed_nav parameter to: %s' % relax_should_be)       
                     
-                    # if relax_should_be and rospy.get_param('explore_edges', True):
-                    #     self.generate_edge_task(*edge_tuple, window_size=repeat_window_secs)
-
             except Exception, e:
                 rospy.logwarn('while checking relaxation state: %s' % e)
 
@@ -115,4 +80,3 @@ if __name__ == '__main__':
     rospy.init_node('nav_relaxant')
     relaxant = NavRelaxant(count_threshold=rospy.get_param('~count_threshold', 5))
     relaxant.run()
-    rospy.spin()


### PR DESCRIPTION
The problem we have is that early estimates of navigation durations can be low, causing navigation actions to be killed even when they are working. The relaxed_nav parameter greatly inflates the estimates to prevent this happening, but must be set manually.

This PR adds a node which automatically sets the value of the relaxed_nav based on the number of nav stats for each edge. This is a rather coarse way of doing it, but given the separation of concerns in the system there is not other way. The better future solution is to get some kind of confidence measure with the estimate.
