### PR TITLE
expected_duration is now being used in mdp executor.

### DIFF
--- a/task_executor/scripts/mdp_task_executor.py
+++ b/task_executor/scripts/mdp_task_executor.py
@@ -224,7 +224,7 @@ class MDPTaskExecutor(BaseTaskExecutor):
             outcome=MdpActionOutcome(probability = 1.0,
                     post_conds = [StringIntPair(string_data = state_var_name, int_data = 1)],
                     duration_probs = [1.0],
-                    durations = [task.max_duration.to_sec()])
+                    durations = [task.expected_duration.to_sec()])
 
             action = MdpAction(name=action_name, 
                      action_server=task.action, 

--- a/task_executor/src/task_executor/base_executor.py
+++ b/task_executor/src/task_executor/base_executor.py
@@ -274,6 +274,9 @@ class BaseTaskExecutor(object):
                 rospy.logwarn('Task %s did not have max_duration set' % (task.action))
                 task.max_duration = rospy.Duration(5 * 60)
 
+            if task.expected_duration.secs == 0:
+                rospy.logwarn('Task %s did not have expected_duration set, using max_duration' % (task.action))
+
             if task.start_after.secs == 0:
                 rospy.logwarn('Task %s did not have start_after set' % (task.action))                
                 task.start_after = now
@@ -306,7 +309,12 @@ class BaseTaskExecutor(object):
             req.task.end_before = rospy.get_rostime() + (req.task.max_duration * 20)
             req.task.execution_time = rospy.get_rostime()
 
+            if task.max_duration.secs == 0:
+                rospy.logwarn('Task %s did not have max_duration set' % (task.action))
+                task.max_duration = rospy.Duration(5 * 60)
 
+            if task.expected_duration.secs == 0:
+                rospy.logwarn('Task %s did not have expected_duration set, using max_duration' % (task.action))
 
             # stop anything else
             if len(self.active_tasks) > 0:


### PR DESCRIPTION
If a task does not have expected_duration set, max_duration is used instead. This is pushed through to the mdp spec