### PR TITLE
Added new combined sort criterion for choosing next tasks.

### DIFF
--- a/strands_executive_msgs/CMakeLists.txt
+++ b/strands_executive_msgs/CMakeLists.txt
@@ -49,6 +49,7 @@ add_service_files(
   IsTaskInterruptible.srv
   GetActiveTasks.srv
   GetGuaranteesForCoSafeTask.srv
+  GetIDs.srv
 )
 
 

--- a/task_executor/launch/mdp-executor.launch
+++ b/task_executor/launch/mdp-executor.launch
@@ -1,5 +1,6 @@
 <launch>
   <arg name="interruptible_wait" default="true"/>
+  <arg name="combined_sort" default="false"/>
   
   <!-- run mdp plan exec -->
   <include file="$(find mdp_plan_exec)/launch/mdp_plan_exec_extended.launch">
@@ -8,6 +9,7 @@
   <!-- mdp task system using mdp navigation -->
   <node pkg="task_executor" type="mdp_task_executor.py" name="mdp_task_executor"  output="screen">
   	<param name="nav_service" type="string" value="mdp" />
+    <param name="combined_sort" type="bool" value="$(arg combined_sort)" />
   </node>
   
     <!-- Utility node used for generating wait behaviours -->

--- a/task_executor/scripts/mdp_task_executor.py
+++ b/task_executor/scripts/mdp_task_executor.py
@@ -224,7 +224,7 @@ class MDPTaskExecutor(BaseTaskExecutor):
             outcome=MdpActionOutcome(probability = 1.0,
                     post_conds = [StringIntPair(string_data = state_var_name, int_data = 1)],
                     duration_probs = [1.0],
-                    durations = [task.max_duration.to_sec()])
+                    durations = [task.expected_duration.to_sec()])
 
             action = MdpAction(name=action_name, 
                      action_server=task.action, 

--- a/task_executor/scripts/mdp_task_executor.py
+++ b/task_executor/scripts/mdp_task_executor.py
@@ -107,6 +107,12 @@ class MDPTaskExecutor(BaseTaskExecutor):
         self.schedule_publish_thread = Thread(target=self.publish_schedule)
         self.schedule_publish_thread.start()
 
+        self.use_combined_sort_criteria = rospy.get_param('~combined_sort', False) 
+        if self.use_combined_sort_criteria:
+            rospy.loginfo('Using combined sort criteria')
+        else:
+            rospy.loginfo('Using separate sort criteria')
+
         self.advertise_services()
         self.tz = tzlocal()
         
@@ -508,15 +514,40 @@ class MDPTaskExecutor(BaseTaskExecutor):
                 self.normal_tasks.remove(mdp_task)
  
 
-        # sort the list of possibles by probability of success, with highest prob at start
-        # sort is stable, so a sequence of sorts will  work, starting with the lowest priorit
 
-        possibles_with_guarantees_in_time  = sorted(possibles_with_guarantees_in_time, key=lambda x: x[0].task.end_before)  
-        possibles_with_guarantees_in_time  = sorted(possibles_with_guarantees_in_time, key=lambda x: x[2].probability, reverse=True)  
-        possibles_with_guarantees_in_time  = sorted(possibles_with_guarantees_in_time, key=lambda x: x[0].task.priority, reverse=True)  
+        if self.use_combined_sort_criteria:
 
-        for possible in possibles_with_guarantees_in_time:
-            rospy.loginfo('%s will take %.2f secs with prio %s and prob %.4f ending before %s' % (possible[0].task.action, possible[2].expected_time.to_sec(), possible[0].task.priority, possible[2].probability, rostime_to_python(possible[0].task.end_before))) 
+            def task_reward(task_tuple):                
+                # sanity check for zero-time case
+                if task_tuple[2].expected_time.secs > 0:
+                    expected_time = task_tuple[2].expected_time.to_sec()
+                else:
+                    expected_time = 1.0
+
+                # sanity check for zero priority case
+                if task_tuple[0].task.priority == 0:
+                    rospy.logwarn('Priority is used for sorting but task %s had a priority of 0' % (task_tuple[0].task.action))
+                    priority = 1.0
+                else:
+                    priority = task_tuple[0].task.priority
+
+                return (priority*task_tuple[2].probability)/expected_time
+
+            possibles_with_guarantees_in_time  = sorted(possibles_with_guarantees_in_time, key=lambda x: task_reward(x), reverse=True)    
+            for possible in possibles_with_guarantees_in_time:
+                rospy.loginfo('%s, with reward %.2f, will take %.2f secs with prio %s and prob %.4f ending before %s' % (possible[0].task.action, task_reward(possible), possible[2].expected_time.to_sec(), possible[0].task.priority, possible[2].probability, rostime_to_python(possible[0].task.end_before))) 
+
+        else:
+
+            # sort the list of possibles by probability of success, with highest prob at start
+            # sort is stable, so a sequence of sorts will  work, starting with the lowest priorit
+
+            possibles_with_guarantees_in_time  = sorted(possibles_with_guarantees_in_time, key=lambda x: x[0].task.end_before)  
+            possibles_with_guarantees_in_time  = sorted(possibles_with_guarantees_in_time, key=lambda x: x[2].probability, reverse=True)  
+            possibles_with_guarantees_in_time  = sorted(possibles_with_guarantees_in_time, key=lambda x: x[0].task.priority, reverse=True)  
+
+            for possible in possibles_with_guarantees_in_time:
+                rospy.loginfo('%s will take %.2f secs with prio %s and prob %.4f ending before %s' % (possible[0].task.action, possible[2].expected_time.to_sec(), possible[0].task.priority, possible[2].probability, rostime_to_python(possible[0].task.end_before))) 
 
         # if at least one task fits into the executable time window
         if len(possibles_with_guarantees_in_time) > 0:

--- a/task_executor/scripts/mdp_task_executor.py
+++ b/task_executor/scripts/mdp_task_executor.py
@@ -525,16 +525,17 @@ class MDPTaskExecutor(BaseTaskExecutor):
             new_active_batch = [possibles_with_guarantees_in_time[0][0]]
             last_successful_spec = (possibles_with_guarantees_in_time[0][1], possibles_with_guarantees_in_time[0][2])
 
-            # greedily combine with the rest
+            # remove the most probable from the list of possibles
             possibles_with_guarantees_in_time = possibles_with_guarantees_in_time[1:]            
 
             # limit the tasks inspected by the batch limit... we are skipping tasks, so just using the batch limit isn't enough
             for possible in possibles_with_guarantees_in_time:
 
-                mdp_task = possible[0]
                 if len(new_active_batch) == self.batch_limit:
                     break                
 
+
+                mdp_task = possible[0]
                 mdp_tasks_to_check = copy(new_active_batch)
                 mdp_tasks_to_check.append(mdp_task)   
                 (mdp_spec, guarantees) = self._get_guarantees_for_batch(mdp_tasks_to_check, estimates_service = mdp_estimates, epoch = now)

--- a/task_executor/scripts/mdp_task_executor.py
+++ b/task_executor/scripts/mdp_task_executor.py
@@ -93,7 +93,7 @@ class MDPTaskExecutor(BaseTaskExecutor):
         self.execution_window = rospy.Duration(1200)
         
         # and the max number of tasks to fit into this window due to MDP scaling issues
-        self.batch_limit = 6
+        self.batch_limit = 5
 
         self.expected_completion_time = rospy.Time()
         self.mdp_exec_thread = Thread(target=self.mdp_exec)    

--- a/task_executor/src/task_executor/base_executor.py
+++ b/task_executor/src/task_executor/base_executor.py
@@ -274,6 +274,9 @@ class BaseTaskExecutor(object):
                 rospy.logwarn('Task %s did not have max_duration set' % (task.action))
                 task.max_duration = rospy.Duration(5 * 60)
 
+            if task.expected_duration.secs == 0:
+                rospy.logwarn('Task %s did not have expected_duration set, using max_duration' % (task.action))
+
             if task.start_after.secs == 0:
                 rospy.logwarn('Task %s did not have start_after set' % (task.action))                
                 task.start_after = now
@@ -306,7 +309,12 @@ class BaseTaskExecutor(object):
             req.task.end_before = rospy.get_rostime() + (req.task.max_duration * 20)
             req.task.execution_time = rospy.get_rostime()
 
+            if task.max_duration.secs == 0:
+                rospy.logwarn('Task %s did not have max_duration set' % (task.action))
+                task.max_duration = rospy.Duration(5 * 60)
 
+            if task.expected_duration.secs == 0:
+                rospy.logwarn('Task %s did not have expected_duration set, using max_duration' % (task.action))
 
             # stop anything else
             if len(self.active_tasks) > 0:

--- a/task_executor/src/task_executor/base_executor.py
+++ b/task_executor/src/task_executor/base_executor.py
@@ -258,6 +258,19 @@ class BaseTaskExecutor(object):
         return [self.active_tasks]
     get_active_tasks_ros_srv.type=GetActiveTasks
 
+
+    def get_ids_ros_srv(self, req):
+        """
+        Gets a bunch of fresh ids
+        """
+        return [[self.get_next_id() for x in range(req.count)]]
+    get_ids_ros_srv.type=GetIDs
+
+    def get_next_id(self):
+        rv = self.task_counter
+        self.task_counter += 1
+        return rv
+
     def add_tasks_ros_srv(self, req):
         """
         Adds a task into the task execution framework.
@@ -266,9 +279,8 @@ class BaseTaskExecutor(object):
         now = rospy.get_rostime()
         task_ids = []
         for task in req.tasks:
-            task.task_id = self.task_counter
-            task_ids.append(task.task_id)
-            self.task_counter += 1
+            task.task_id = self.get_next_id()
+            task_ids.append(task.task_id)            
             
             if task.max_duration.secs == 0:
                 rospy.logwarn('Task %s did not have max_duration set' % (task.action))

--- a/task_executor/src/task_executor/base_executor.py
+++ b/task_executor/src/task_executor/base_executor.py
@@ -327,12 +327,13 @@ class BaseTaskExecutor(object):
             req.task.end_before = rospy.get_rostime() + (req.task.max_duration * 20)
             req.task.execution_time = rospy.get_rostime()
 
-            if task.max_duration.secs == 0:
-                rospy.logwarn('Task %s did not have max_duration set' % (task.action))
-                task.max_duration = rospy.Duration(5 * 60)
+            if req.task.max_duration.secs == 0:
+                rospy.logwarn('Task %s did not have max_duration set' % (req.task.action))
+                req.task.max_duration = rospy.Duration(5 * 60)
 
-            if task.expected_duration.secs == 0:
-                rospy.logwarn('Task %s did not have expected_duration set, using max_duration' % (task.action))
+            if req.task.expected_duration.secs == 0:
+                rospy.logwarn('Task %s did not have expected_duration set, using max_duration' % (req.task.action))
+                req.task.expected_duration = req.task.max_duration
 
             # stop anything else
             if len(self.active_tasks) > 0:


### PR DESCRIPTION
The new combined sort criterion is priority*p(success)/expected_time (i.e. reward per unit time) as requested in #272. The old sort criterion criterio is still the default behaviour. To use the new sorting, add `combined_sort:=true` when launching the executive launch file.

This closes #272