### PR TITLE
Dealing with windows more actively

### DIFF
--- a/mdp_plan_exec/src/mdp_plan_exec/action_executor.py
+++ b/mdp_plan_exec/src/mdp_plan_exec/action_executor.py
@@ -4,7 +4,7 @@ from actionlib_msgs.msg import GoalStatus
 from mongodb_store.message_store import MessageStoreProxy
 import mongodb_store.util as dc_util
 from strands_executive_msgs.msg import MdpAction, Task
-
+from strands_executive_msgs.srv import IsTaskInterruptible
 
 class ActionExecutor(object):
     def __init__(self):
@@ -66,6 +66,25 @@ class ActionExecutor(object):
                 res=action_outcome_msg
         return res
     
+
+    def is_action_interruptible(self, action):
+        if action is None:
+            rospy.logwarn('is_action_interruptible passed a None, returning True')
+            return True
+
+        try:
+            srv_name = action + '_is_interruptible'
+            rospy.wait_for_service(srv_name, timeout=1)    
+            is_interruptible = rospy.ServiceProxy(srv_name, IsTaskInterruptible)
+            return is_interruptible().status
+        except rospy.ROSException as exc:
+            rospy.logdebug('%s service does not exist, treating as interruptible')
+            return True
+        except rospy.ServiceException as exc:
+            rospy.logwarn(exc.message)
+            return True
+
+
     def execute_action(self, action_msg):
         self.cancelled=False
         rospy.loginfo("Executing " + action_msg.name + ". Actionlib server is: " + action_msg.action_server)
@@ -88,10 +107,18 @@ class ActionExecutor(object):
                 
                 action_finished = False
                 timer=0
-                while (not action_finished) and (timer < max_action_duration + wiggle_room) and (not self.cancelled):
+
+
+
+                while (not action_finished) and (not self.cancelled):
                     timer += poll_wait.to_sec()
                     action_finished = action_client.wait_for_result(poll_wait)
-                    
+                    if timer > (max_action_duration + wiggle_room):
+                        if self.is_action_interruptible(action_msg.action_server):
+                            break   
+                        else:
+                            rospy.logwarn('Action execution has timed out but is not interruptible, so execution continues')
+
                 if not action_finished:
                     if self.cancelled:
                         rospy.logwarn("Policy execution has been preempted by another process")

--- a/task_executor/launch/mdp-executor.launch
+++ b/task_executor/launch/mdp-executor.launch
@@ -1,6 +1,7 @@
 <launch>
   <arg name="interruptible_wait" default="true"/>
   <arg name="combined_sort" default="false"/>
+  <arg name="close_windows" default="true"/>
   
   <!-- run mdp plan exec -->
   <include file="$(find mdp_plan_exec)/launch/mdp_plan_exec_extended.launch">
@@ -10,6 +11,7 @@
   <node pkg="task_executor" type="mdp_task_executor.py" name="mdp_task_executor"  output="screen">
   	<param name="nav_service" type="string" value="mdp" />
     <param name="combined_sort" type="bool" value="$(arg combined_sort)" />
+    <param name="close_windows" type="bool" value="$(arg close_windows)" />
   </node>
   
     <!-- Utility node used for generating wait behaviours -->

--- a/task_executor/scripts/mdp_task_executor.py
+++ b/task_executor/scripts/mdp_task_executor.py
@@ -158,8 +158,7 @@ class MDPTaskExecutor(BaseTaskExecutor):
                 task_spec_pairs.append((task, spec))
 
             self.add_specs(task_spec_pairs)        
-            self.log_task_events(tasks, TaskEvent.ADDED, rospy.get_rostime())                
-            self.service_lock.release()
+            self.log_task_events(tasks, TaskEvent.ADDED, rospy.get_rostime())                            
             return [task_ids]
         finally:    
             self.service_lock.release()

--- a/task_executor/src/task_executor/task_query.py
+++ b/task_executor/src/task_executor/task_query.py
@@ -14,8 +14,6 @@ from task_executor.utils import rostime_to_python
 
 
 
-
-
 def remove_duplicates(results):
     seen = set()
     seen_add = seen.add

--- a/task_executor/src/task_executor/utils.py
+++ b/task_executor/src/task_executor/utils.py
@@ -4,6 +4,21 @@ from task_executor.msg import *
 from datetime import datetime, timedelta
 from std_msgs.msg import String
 
+
+def max_duration(d1,d2):
+    if d1.to_sec() > d2.to_sec():
+        return d1
+    else:
+        return d2
+
+def ros_duration_to_string(duration):
+    return "%s" % duration.to_sec()
+
+def ros_time_to_string(time):
+    return datetime.fromtimestamp(time.to_sec()).strftime('%d/%m/%y %H:%M:%S')    
+
+
+
 class TestTaskAction(object):
     """ 
     Creates the action servers the example tasks require.

--- a/wait_action/scripts/wait_node.py
+++ b/wait_action/scripts/wait_node.py
@@ -49,17 +49,26 @@ class WaitServer(AbstractTaskServer):
                 target = now + a_really_long_time
                 # rospy.loginfo("waiting a really long time")
 
+            # for testing overruns
+            # if True:
+            #     a_really_long_time = rospy.Duration(60 * 60 * 24 * 3)
+            #     target = now + a_really_long_time
+
             rospy.loginfo("target wait time: %s"
                           % datetime.fromtimestamp(target.secs))
+
+
 
             # how often to provide feedback
             feedback_secs = 5.0
             feedback = WaitFeedback()
             # how long to wait
             wait_duration_secs = target.secs - now.secs
+            
 
             # the rate to publish feedback at/check time at
             r = rospy.Rate(1.0/feedback_secs)
+
 
             count = 1.0
             feedback_steps = wait_duration_secs/feedback_secs


### PR DESCRIPTION
This checks navigation time before opening a window. Also it adds option to terminate execution of a batch of task when the lowest time window has passed.

To use this option add `close_windows:=true` to the command of launching the system, e.g.

```
roslaunch --wait task_executor mdp-executor.launch close_windows:=true
```

This fixes #281 and #283 