### PR TITLE
 reading the calendar tasks description for filling task yaml paramete…

### DIFF
--- a/gcal_routine/src/gcal_routine/queue_routine_runner.py
+++ b/gcal_routine/src/gcal_routine/queue_routine_runner.py
@@ -76,7 +76,8 @@ class GCalRoutineRunner(object):
                     rospy.loginfo('setting priority of tasks to %d'
                                   % prio)
                     for t in tasks:
-                        t.priority = prio
+                        if not t.priority:
+                            t.priority = prio
 
                     rospy.loginfo('Sending %d tasks to the scheduler'
                                   % (len(tasks)))

--- a/gcal_routine/src/gcal_routine/tools.py
+++ b/gcal_routine/src/gcal_routine/tools.py
@@ -161,8 +161,12 @@ class GCal:
                  (start_after.secs, start_after.nsecs)
             eb = "end_before: {secs: %d, nsecs: %d}" % \
                  (end_before.secs, end_before.nsecs)
-            sn = "start_node_id: '%s'" % gcal_event['location']
-            en = "end_node_id: '%s'" % gcal_event['location']
+            if gcal_event.has_key('location'):
+                sn = "start_node_id: '%s'" % gcal_event['location']
+                en = "end_node_id: '%s'" % gcal_event['location']
+            else:
+                sn = "start_node_id: ''"
+                en = "end_node_id: ''"
             desc_yaml = None
             if gcal_event.has_key('description'):
                 ds = "description: '%s'" % gcal_event['description']

--- a/gcal_routine/src/gcal_routine/tools.py
+++ b/gcal_routine/src/gcal_routine/tools.py
@@ -174,10 +174,10 @@ class GCal:
                 ds = "description: "
 
             yaml_s = "{%s, %s, %s, %s, %s}" % (sa, eb, sn, en, ds)
-            yaml_o = yaml.load(yaml_s)
 
             # override the fields specified in the task description
             if desc_yaml is not None:
+                yaml_o = yaml.load(yaml_s)
                 yaml_o.update(desc_yaml)
                 yaml_s = str(yaml_o)
 


### PR DESCRIPTION
…rs (e.g. priority, end_node_id).

Allows to override default parameters set by the gcal routine. For example writing  
```
priority: 5
end_node_id: WayPoint12
```
in a task description results in the task having priority 5 and ending in `WayPoint12` instead of the starting node set by default.

I am quite sure everything works as before if the description is left empty. 